### PR TITLE
Remove demo credentials block from login page

### DIFF
--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -157,19 +157,6 @@ function Login({ onLogin }) {
               </Button>
             </Typography>
           </Box>
-
-          {isLogin && (
-            <Box sx={{ mt: 3, p: 2, bgcolor: '#f5f5f5', borderRadius: 1 }}>
-              <Typography variant="caption" color="textSecondary" display="block">
-                <strong>Demo Credentials:</strong>
-              </Typography>
-              <Typography variant="caption" color="textSecondary">
-                📧 Email: admin@company.com
-                <br />
-                🔑 Password: SecurePass123
-              </Typography>
-            </Box>
-          )}
         </Card>
       </Box>
     </Container>


### PR DESCRIPTION
## 🎯 Description

Remove the "Demo Credentials" information block from the login page for improved security and cleaner UI.

## 📝 Changes

- **frontend/src/pages/Login.jsx**: Removed the demo credentials block that displayed `admin@company.com` and `SecurePass123`

## 🔒 Security Rationale

The demo credentials block poses a minor security risk by:
- Publicly exposing example credentials
- Making it easier for unauthorized users to identify demo/test accounts
- Reducing the perceived security posture of the application

## ✅ Testing

- [x] Login page renders correctly without the credentials block
- [x] Form functionality remains unchanged
- [x] No other components are affected

## 📋 Checklist

- [x] Code follows project style guidelines
- [x] No breaking changes
- [x] Changes are isolated to frontend only

---

*This PR was created as requested to clean up the login page.*