### PR TITLE
feat(websocket): Add auto-refresh on consensus and issue events

### DIFF
--- a/app/routes/estimates.py
+++ b/app/routes/estimates.py
@@ -8,6 +8,7 @@ from app.database import get_db
 from app.schemas.estimate import EstimateCreate, EstimateResponse, EstimateSummary
 from app.services.estimation_service import EstimationService
 from app.utils.security import get_current_user
+from app.websockets.session_ws import manager
 
 router = APIRouter()
 estimation_service = EstimationService()
@@ -20,7 +21,18 @@ async def create_estimate(
     db: Session = Depends(get_db),
 ):
     """Create an estimate for an issue"""
-    estimate = estimation_service.create_estimate(db, estimate_data)
+    estimate, consensus_data = estimation_service.create_estimate(db, estimate_data)
+
+    # Broadcast consensus_reached event if consensus was achieved
+    if consensus_data:
+        await manager.broadcast(consensus_data["session_id"], {
+            "type": "consensus_reached",
+            "issue_id": consensus_data["issue_id"],
+            "issue_key": consensus_data["issue_key"],
+            "final_estimate": consensus_data["final_score"],
+            "is_joker": False,
+        })
+
     return estimate
 
 

--- a/app/routes/sessions.py
+++ b/app/routes/sessions.py
@@ -12,6 +12,7 @@ from app.services.jira_service import JiraService
 from app.services.issue_service import IssueService
 from app.utils.security import get_current_user
 from app.routes.jira import FailedIssue
+from app.websockets.session_ws import manager
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
@@ -260,9 +261,10 @@ async def import_issues_to_session(
         
         # Add successful issues to session
         from app.models.issue import Issue
-        
+
         imported_count = 0
         processed_keys = set()
+        imported_issues_data = []  # Track newly imported issues for WebSocket broadcast
         
         for jira_issue in successful_issues:
             try:
@@ -316,6 +318,12 @@ async def import_issues_to_session(
                 db.add(new_issue)
                 db.flush()
                 imported_count += 1
+                # Track for WebSocket broadcast
+                imported_issues_data.append({
+                    "issue_id": new_issue.id,
+                    "issue_key": issue_key,
+                    "issue_title": title,
+                })
                 logger.info(f"Added issue {issue_key} (ID: {new_issue.id}) to session {session_id}")
                 
             except Exception as e:
@@ -335,7 +343,16 @@ async def import_issues_to_session(
             f"Successfully imported {imported_count} issue(s) to session {session_id}, "
             f"{len(failed_issues)} failed"
         )
-        
+
+        # Broadcast issue_added events for newly imported issues
+        for issue_data in imported_issues_data:
+            await manager.broadcast(session_id, {
+                "type": "issue_added",
+                "issue_id": issue_data["issue_id"],
+                "issue_key": issue_data["issue_key"],
+                "issue_title": issue_data["issue_title"],
+            })
+
         # Build failed issues response
         failed_issues_response = [
             FailedIssue(

--- a/app/services/estimation_service.py
+++ b/app/services/estimation_service.py
@@ -11,14 +11,18 @@ class EstimationService:
     """Estimation business logic"""
 
     @staticmethod
-    def create_estimate(db: Session, estimate_data: EstimateCreate) -> Estimate:
-        """Create an estimate"""
+    def create_estimate(db: Session, estimate_data: EstimateCreate) -> tuple[Estimate, dict | None]:
+        """Create an estimate
+
+        Returns:
+            tuple: (estimate, consensus_data) where consensus_data is dict if consensus reached, None otherwise
+        """
         # Check if user already estimated this issue
         existing = db.query(Estimate).filter(
             Estimate.issue_id == estimate_data.issue_id,
             Estimate.user_id == estimate_data.user_id,
         ).first()
-        
+
         if existing:
             # Update existing estimate
             existing.story_points = estimate_data.story_points
@@ -29,16 +33,16 @@ class EstimationService:
             estimate_dict = estimate_data.dict(exclude={'session_id'})
             db_estimate = Estimate(**estimate_dict)
             db.add(db_estimate)
-        
+
         db.commit()
-        
+
         # Get the final estimate object (existing or newly created)
         final_estimate = existing if existing else db_estimate
-        
+
         # Check if we should auto-apply the estimate
-        EstimationService._check_consensus(db, estimate_data.issue_id)
-        
-        return final_estimate
+        consensus_data = EstimationService._check_consensus(db, estimate_data.issue_id)
+
+        return final_estimate, consensus_data
 
     @staticmethod
     def get_estimates(
@@ -131,59 +135,69 @@ class EstimationService:
         return query.order_by(Estimate.created_at.desc()).offset(skip).limit(limit).all()
 
     @staticmethod
-    def _check_consensus(db: Session, issue_id: int) -> bool:
-        """Check if estimates have reached consensus and auto-apply"""
+    def _check_consensus(db: Session, issue_id: int) -> dict | None:
+        """Check if estimates have reached consensus and auto-apply
+
+        Returns:
+            dict with consensus data if reached, None otherwise
+            dict keys: issue_id, issue_key, session_id, final_score
+        """
         issue = db.query(Issue).filter(Issue.id == issue_id).first()
         if not issue or issue.is_estimated:
-            return False
-        
+            return None
+
         # Get session estimators count
         from app.models.session import Session as SessionModel
         session = db.query(SessionModel).filter(SessionModel.id == issue.session_id).first()
         if not session:
-            return False
-        
+            return None
+
         # Get estimators count (people assigned to estimate tasks)
         # If no estimators assigned, use all participants as fallback
         if session.estimators and len(session.estimators) > 0:
             estimators_count = len(session.estimators)
         else:
             estimators_count = len(session.participants) if session.participants else 0
-        
+
         if estimators_count == 0:
-            return False
-        
+            return None
+
         # Get all estimates (both regular and joker)
         estimates = db.query(Estimate).filter(Estimate.issue_id == issue_id).all()
         estimate_count = len(estimates)
-        
+
         # Check if all estimators have voted (including joker votes)
         if estimate_count < estimators_count:
-            return False
-        
+            return None
+
         # Only consider non-joker estimates for consensus calculation
         valid_estimates = [e for e in estimates if not e.is_joker]
-        
+
         # If no valid estimates (only jokers), cannot reach consensus
         if not valid_estimates:
-            return False
-        
+            return None
+
         points = [e.story_points for e in valid_estimates]
         variance = max(points) - min(points)
-        
+
         # Check if consensus: max - min <= 2 points AND all estimators have voted
         if variance <= 2 and estimate_count >= estimators_count:
             # Calculate average and round to nearest valid score
             avg = sum(points) / len(points)
             valid_scores = [1, 2, 4, 8, 16]
             final_score = min(valid_scores, key=lambda x: abs(x - avg))
-            
+
             # Apply estimate
             issue.story_points = final_score
             issue.is_estimated = True
             db.add(issue)
             db.commit()
-            
-            return True
-        
-        return False
+
+            return {
+                "issue_id": issue.id,
+                "issue_key": issue.jira_key,
+                "session_id": issue.session_id,
+                "final_score": final_score,
+            }
+
+        return None

--- a/frontend/src/pages/SessionDetail.jsx
+++ b/frontend/src/pages/SessionDetail.jsx
@@ -38,6 +38,7 @@ function SessionDetail() {
   const [currentUser, setCurrentUser] = useState(null);
   const [isCreator, setIsCreator] = useState(false);
   const [consensusNotification, setConsensusNotification] = useState(null);
+  const [issueAddedNotification, setIssueAddedNotification] = useState(null);
   const [ws, setWs] = useState(null);
 
   // Edit dialog state
@@ -124,7 +125,7 @@ function SessionDetail() {
       } else if (data.type === 'consensus_reached') {
         // Consensus reached - show notification and auto-refresh
         console.log('Consensus reached for issue:', data.issue_id, 'Final estimate:', data.final_estimate);
-        
+
         // Show notification about consensus
         setConsensusNotification({
           issueId: data.issue_id,
@@ -132,13 +133,31 @@ function SessionDetail() {
           finalEstimate: data.final_estimate,
           isJoker: data.is_joker,
         });
-        
+
         // Auto-refresh data to show the final estimate
         loadSessionData();
-        
+
         // Auto-hide notification after 5 seconds
         setTimeout(() => {
           setConsensusNotification(null);
+        }, 5000);
+      } else if (data.type === 'issue_added') {
+        // New issue added - show notification and auto-refresh
+        console.log('Issue added:', data.issue_key, data.issue_title);
+
+        // Show notification about new issue
+        setIssueAddedNotification({
+          issueId: data.issue_id,
+          issueKey: data.issue_key,
+          issueTitle: data.issue_title,
+        });
+
+        // Auto-refresh data to show the new issue
+        loadSessionData();
+
+        // Auto-hide notification after 5 seconds
+        setTimeout(() => {
+          setIssueAddedNotification(null);
         }, 5000);
       }
     };
@@ -367,6 +386,12 @@ function SessionDetail() {
             {consensusNotification.isJoker ? 'Abstain (J)' : `${consensusNotification.finalEstimate} story points`}
           </strong>
           . Страница обновлена автоматически.
+        </Alert>
+      )}
+
+      {issueAddedNotification && (
+        <Alert severity="info" sx={{ mb: 2 }} onClose={() => setIssueAddedNotification(null)}>
+          ➕ <strong>Новая задача!</strong> {issueAddedNotification.issueKey}: {issueAddedNotification.issueTitle}
         </Alert>
       )}
 


### PR DESCRIPTION
## Summary

- Implement WebSocket auto-refresh when consensus is reached (Phase 1)
- Implement WebSocket auto-refresh when new issues are added (Phase 2)
- Both events trigger page refresh and show notification that auto-dismisses after 5 seconds

Closes #20

## Changes

### Backend

**app/services/estimation_service.py:**
- `_check_consensus()` now returns dict with consensus data instead of bool
- `create_estimate()` returns tuple `(estimate, consensus_data)`

**app/routes/estimates.py:**
- Broadcast `consensus_reached` event when consensus is achieved

**app/routes/sessions.py:**
- Broadcast `issue_added` event for each newly imported issue

### Frontend

**frontend/src/pages/SessionDetail.jsx:**
- Added `issueAddedNotification` state
- Added `issue_added` WebSocket event handler
- Added info Alert UI for new issue notifications

## Event Structures

```json
// consensus_reached
{
  "type": "consensus_reached",
  "issue_id": 123,
  "issue_key": "DEVOPS-456",
  "final_estimate": 8,
  "is_joker": false
}

// issue_added
{
  "type": "issue_added",
  "issue_id": 456,
  "issue_key": "DEVOPS-789",
  "issue_title": "Implement feature X"
}
```

## Test plan

- [x] Open session in two browser tabs
- [x] Test consensus_reached: Both estimators vote same points → notification appears for both
- [x] Test issue_added: Import new issue → notification appears in other tab
- [x] Verify notifications auto-dismiss after 5 seconds
- [x] Verify manual close button works on notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)